### PR TITLE
smaller flyout arrow

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -278,24 +278,27 @@ function Flyout_UpdateFlyoutArrow(button)
    arrow:Show()
    arrow.texture:ClearAllPoints()
 
+   local size1 = 10  -- large value: 20
+   local size2 = 6  -- large value: 12
+
    if direction == 'BOTTOM' then
-      arrow.texture:SetWidth(20)
-      arrow.texture:SetHeight(12)
+      arrow.texture:SetWidth(size1)
+      arrow.texture:SetHeight(size2)
       arrow.texture:SetTexCoord(0, 0.565, 0.315, 0)
       arrow.texture:SetPoint('BOTTOM', arrow, 0, -6)
    elseif direction == 'LEFT' then
-      arrow.texture:SetWidth(12)
-      arrow.texture:SetHeight(20)
+      arrow.texture:SetWidth(size2)
+      arrow.texture:SetHeight(size1)
       arrow.texture:SetTexCoord(0, 0.315, 0.375, 1)
       arrow.texture:SetPoint('LEFT', arrow, -6, 0)
    elseif direction == 'RIGHT' then
-      arrow.texture:SetWidth(12)
-      arrow.texture:SetHeight(20)
+      arrow.texture:SetWidth(size2)
+      arrow.texture:SetHeight(size1)
       arrow.texture:SetTexCoord(0.315, 0, 0.375, 1)
       arrow.texture:SetPoint('RIGHT', arrow, 6, 0)
    else
-      arrow.texture:SetWidth(20)
-      arrow.texture:SetHeight(12)
+      arrow.texture:SetWidth(size1)
+      arrow.texture:SetHeight(size2)
       arrow.texture:SetTexCoord(0, 0.565, 0, 0.315)
       arrow.texture:SetPoint('TOP', arrow, 0, 6)
    end


### PR DESCRIPTION
Thanks for creating Flyout. It's fantastic! What a clever addon! The arrow is incredibly large, blurry, stretched and ugly by default though. It really doesn't need to be that large and visible. It even covers up the spell icons and hotkey text, and even covers the first icon of the flyout menu itself! People will not forget what button has a flyout menu and it doesn't need to be this large. So I have made it smaller and thereby sharper and cleaner.

It's up to you if you want this change or not, or if you want to make it configurable somehow, but I'll be running this change locally. :smile: 

Old:

![image](https://github.com/user-attachments/assets/d0cb238f-b8bd-4c99-84ab-b469e6d70ee2)

New:

![image](https://github.com/user-attachments/assets/51e9df51-d9a5-4d9d-b96c-ccb05b736c8a)
