### PR TITLE
Stickiness, cooldowns, highlighting, arrow scaling, and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@ Flyout is a World of Warcraft Vanilla (1.12) addon that mimics the flyout featur
 1. Open your macros and create a new macro
 2. In the macro body, start by typing `/flyout` and then the names of spells/macros separated by a semicolon
    - To use a specific rank of a spell, use `Frostbolt(Rank 1)`. To use the highest rank available, use `Frostbolt`
+   - To keep the flyout open until you move the mouse off it, use the 'sticky' macro condition (`/flyout [sticky] Disenchant; Enchanting`)
 
    ![Macro body example](screenshots/macro.png)
 
 
-4. Drag the newly created macro to one of your action bars and you're good to go
+3. Drag the newly created macro to one of your action bars and you're good to go
 
    ![Flyout](screenshots/bar.png)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Flyout
 
-Flyout is a World of Warcraft Vanilla (1.12) addon that mimicks the flyout feature implemented in later expansions.
+Flyout is a World of Warcraft Vanilla (1.12) addon that mimics the flyout feature implemented in later expansions.
 
 ## How to
 

--- a/Templates.xml
+++ b/Templates.xml
@@ -33,8 +33,7 @@
                 else
                     Flyout_ExecuteMacro(this.action)
                 end
-
-                Flyout_Hide()
+                Flyout_Hide(true)
             </OnClick>
             <OnEnter>
                 GameTooltip_SetDefaultAnchor(GameTooltip, this)

--- a/main.lua
+++ b/main.lua
@@ -300,19 +300,3 @@ function Flyout_UpdateFlyoutArrow(button)
       arrow.texture:SetPoint('TOP', arrow, 0, 6)
    end
 end
-
-local Flyout_UseAction = UseAction
-function UseAction(slot, checkCursor)
-   Flyout_UseAction(slot, checkCursor)
-
-   local button = Flyout_GetActionButton(slot)
-   if button and button.flyout then
-      if button.flyout[1] == 0 then
-         CastSpell(button.flyout[2], 'spell')
-      else
-         Flyout_ExecuteMacro(button.flyout[2])
-      end
-   end
-
-   Flyout_Hide()
-end

--- a/main.lua
+++ b/main.lua
@@ -12,7 +12,7 @@ local bars = {
 
 FLYOUT_DEFAULT_CONFIG = {
    ['REVISION'] = revision,
-   ['BUTTON_SIZE'] = 24,
+   ['BUTTON_SIZE'] = 28,
    ['BORDER_COLOR'] = { 0, 0, 0 },
    ['ARROW_SCALE'] = 5/9,
 }

--- a/main.lua
+++ b/main.lua
@@ -10,6 +10,9 @@ local bars = {
    'MultiBarLeft'
 }
 
+local ARROW_SCALE = 5/9  -- Relative size compared to action button.
+local ARROW_RATIO = 0.6  -- Height to width.
+
 -- upvalues
 local ActionButton_GetPagedID = ActionButton_GetPagedID
 local ChatEdit_SendText = ChatEdit_SendText
@@ -365,24 +368,27 @@ function Flyout_UpdateFlyoutArrow(button)
    arrow:Show()
    arrow.texture:ClearAllPoints()
 
+   local arrowWideDimension = (button:GetWidth() or 36) * ARROW_SCALE
+   local arrowShortDimension = arrowWideDimension * ARROW_RATIO
+
    if direction == 'BOTTOM' then
-      arrow.texture:SetWidth(20)
-      arrow.texture:SetHeight(12)
+      arrow.texture:SetWidth(arrowWideDimension)
+      arrow.texture:SetHeight(arrowShortDimension)
       arrow.texture:SetTexCoord(0, 0.565, 0.315, 0)
       arrow.texture:SetPoint('BOTTOM', arrow, 0, -6)
    elseif direction == 'LEFT' then
-      arrow.texture:SetWidth(12)
-      arrow.texture:SetHeight(20)
+      arrow.texture:SetWidth(arrowShortDimension)
+      arrow.texture:SetHeight(arrowWideDimension)
       arrow.texture:SetTexCoord(0, 0.315, 0.375, 1)
       arrow.texture:SetPoint('LEFT', arrow, -6, 0)
    elseif direction == 'RIGHT' then
-      arrow.texture:SetWidth(12)
-      arrow.texture:SetHeight(20)
+      arrow.texture:SetWidth(arrowShortDimension)
+      arrow.texture:SetHeight(arrowWideDimension)
       arrow.texture:SetTexCoord(0.315, 0, 0.375, 1)
       arrow.texture:SetPoint('RIGHT', arrow, 6, 0)
    else
-      arrow.texture:SetWidth(20)
-      arrow.texture:SetHeight(12)
+      arrow.texture:SetWidth(arrowWideDimension)
+      arrow.texture:SetHeight(arrowShortDimension)
       arrow.texture:SetTexCoord(0, 0.565, 0, 0.315)
       arrow.texture:SetPoint('TOP', arrow, 0, 6)
    end

--- a/main.lua
+++ b/main.lua
@@ -38,13 +38,31 @@ local function strtrim(str)
    return strsub(str, e + 1, s - 1)
 end
 
+local function tblclear(tbl)
+	if type(tbl) ~= "table" then
+		return
+	end
+
+	-- Clear array-type tables first so table.insert will start over at 1.
+	for i = sizeof(tbl), 1, -1 do
+		table.remove(tbl, i)
+	end
+
+	-- Remove any remaining associative table elements.
+	-- Credit: https://stackoverflow.com/a/27287723
+	for k in next, tbl do
+		rawset(tbl, k, nil)
+	end
+end
+
+local strSplitReturn = {}  -- Reusable table for strsplit().
 local function strsplit(str, delimiter)
-   local t = {}
+   tblclear(strSplitReturn)
    strgsub(str, '([^' .. delimiter .. ']+)', function(value)
-      insert(t, strtrim(value))
+      insert(strSplitReturn, strtrim(value))
    end)
 
-   return t
+   return strSplitReturn
 end
 
 -- credit: https://github.com/DanielAdolfsson/CleverMacro

--- a/main.lua
+++ b/main.lua
@@ -10,7 +10,13 @@ local bars = {
    'MultiBarLeft'
 }
 
-local ARROW_SCALE = 5/9  -- Relative size compared to action button.
+FLYOUT_DEFAULT_CONFIG = {
+   ['REVISION'] = revision,
+   ['BUTTON_SIZE'] = 24,
+   ['BORDER_COLOR'] = { 0, 0, 0 },
+   ['ARROW_SCALE'] = 5/9,
+}
+
 local ARROW_RATIO = 0.6  -- Height to width.
 
 -- upvalues
@@ -177,11 +183,13 @@ end
 local function HandleEvent()
    if event == 'VARIABLES_LOADED' then
       if not Flyout_Config or (Flyout_Config['REVISION'] == nil or Flyout_Config['REVISION'] ~= revision) then
-         Flyout_Config = {
-            ['REVISION'] = revision,
-            ['BUTTON_SIZE'] = 24,
-            ['BORDER_COLOR'] = { 0, 0, 0 },
-         }
+         Flyout_Config = {}
+      end
+      -- Initialize defaults if not present.
+      for key, value in pairs(FLYOUT_DEFAULT_CONFIG) do
+         if not Flyout_Config[key] then
+            Flyout_Config[key] = value
+         end
       end
    elseif event == 'ACTIONBAR_SLOT_CHANGED' then
       Flyout_Hide(true)  -- Keep sticky menus open.
@@ -368,7 +376,7 @@ function Flyout_UpdateFlyoutArrow(button)
    arrow:Show()
    arrow.texture:ClearAllPoints()
 
-   local arrowWideDimension = (button:GetWidth() or 36) * ARROW_SCALE
+   local arrowWideDimension = (button:GetWidth() or 36) * Flyout_Config['ARROW_SCALE']
    local arrowShortDimension = arrowWideDimension * ARROW_RATIO
 
    if direction == 'BOTTOM' then

--- a/main.lua
+++ b/main.lua
@@ -393,3 +393,19 @@ function Flyout_UpdateFlyoutArrow(button)
       arrow.texture:SetPoint('TOP', arrow, 0, 6)
    end
 end
+
+local Flyout_UseAction = UseAction
+function UseAction(slot, checkCursor)
+   Flyout_UseAction(slot, checkCursor)
+
+   local button = Flyout_GetActionButton(slot)
+   if button and button.flyout then
+      if button.flyout[1] == 0 then
+         CastSpell(button.flyout[2], 'spell')
+      else
+         Flyout_ExecuteMacro(button.flyout[2])
+      end
+   end
+
+   Flyout_Hide()
+end

--- a/main.lua
+++ b/main.lua
@@ -119,15 +119,6 @@ local function UpdateBarButton(slot)
               end
 
                body = strsub(body, e + 1)
-               for _, n in (strsplit(body, ';')) do
-                  local spellSlot = GetSpellSlotByName(n)
-                  if spellSlot then
-                     button.flyout = { 0, spellSlot }
-                  else
-                     button.flyout = { 1, GetMacroIndexByName(n) }
-                  end
-                  break
-               end
 
                Flyout_UpdateFlyoutArrow(button)
 

--- a/options.lua
+++ b/options.lua
@@ -32,18 +32,38 @@ SlashCmdList['FLYOUT'] = function(msg)
    end
 
    if not args[1] then
-      DEFAULT_CHAT_FRAME:AddMessage("/flyout size [number] - set flyout button size")
-      DEFAULT_CHAT_FRAME:AddMessage("/flyout color - adjust the color of the flyout border")
+      DEFAULT_CHAT_FRAME:AddMessage("/flyout size [number|reset] - set flyout button size")
+      DEFAULT_CHAT_FRAME:AddMessage("/flyout color [reset] - adjust the color of the flyout border")
+      DEFAULT_CHAT_FRAME:AddMessage("/flyout arrow [number|reset] - adjust the relative size of the flyout arrow")
       DEFAULT_CHAT_FRAME:AddMessage(" ")
    elseif args[1] == 'size' then
-      if args[2] and type(tonumber(args[2])) == 'number' then
-         Flyout_Config['BUTTON_SIZE'] = tonumber(args[2])
-
-         DEFAULT_CHAT_FRAME:AddMessage("Flyout button size has been set to " .. args[2] .. ".")
+      if args[2] then
+         if type(tonumber(args[2])) == 'number' then
+            Flyout_Config['BUTTON_SIZE'] = tonumber(args[2])
+         elseif args[2] == 'reset' then
+            Flyout_Config['BUTTON_SIZE'] = FLYOUT_DEFAULT_CONFIG['BUTTON_SIZE']
+         end
+         DEFAULT_CHAT_FRAME:AddMessage("Flyout button size has been set to " .. Flyout_Config['BUTTON_SIZE'] .. ".")
       end
    elseif args[1] == 'color' then
-      ShowColorPicker(Flyout_Config['BORDER_COLOR'][1], Flyout_Config['BORDER_COLOR'][2], Flyout_Config['BORDER_COLOR'][3], ColorPickerCallback)
-
-      DEFAULT_CHAT_FRAME:AddMessage("Use the color picker to pick a border color. Click 'Okay' once you're done or 'Cancel' to keep the current color.")
+      if args[2] == 'reset' then
+         Flyout_Config['BORDER_COLOR'][1] = FLYOUT_DEFAULT_CONFIG['BORDER_COLOR'][1]
+         Flyout_Config['BORDER_COLOR'][2] = FLYOUT_DEFAULT_CONFIG['BORDER_COLOR'][2]
+         Flyout_Config['BORDER_COLOR'][3] = FLYOUT_DEFAULT_CONFIG['BORDER_COLOR'][3]
+         DEFAULT_CHAT_FRAME:AddMessage("Flyout border color has been reset.")
+      else
+         ShowColorPicker(Flyout_Config['BORDER_COLOR'][1], Flyout_Config['BORDER_COLOR'][2], Flyout_Config['BORDER_COLOR'][3], ColorPickerCallback)
+         DEFAULT_CHAT_FRAME:AddMessage("Use the color picker to pick a border color. Click 'Okay' once you're done or 'Cancel' to keep the current color.")
+      end
+   elseif args[1] == 'arrow' then
+      if args[2] then
+         if type(tonumber(args[2])) == 'number' then
+            Flyout_Config['ARROW_SCALE'] = tonumber(args[2])
+         elseif args[2] == 'reset' then
+            Flyout_Config['ARROW_SCALE'] = FLYOUT_DEFAULT_CONFIG['ARROW_SCALE']
+         end
+         DEFAULT_CHAT_FRAME:AddMessage("Flyout arrow scale has been set to " .. Flyout_Config['ARROW_SCALE'] .. ".")
+         Flyout_UpdateBars()
+      end
    end
 end

--- a/options.lua
+++ b/options.lua
@@ -32,9 +32,9 @@ SlashCmdList['FLYOUT'] = function(msg)
    end
 
    if not args[1] then
-      DEFAULT_CHAT_FRAME:AddMessage("/flyout size [number|reset] - set flyout button size")
+      DEFAULT_CHAT_FRAME:AddMessage("/flyout size [number||reset] - set flyout button size")
       DEFAULT_CHAT_FRAME:AddMessage("/flyout color [reset] - adjust the color of the flyout border")
-      DEFAULT_CHAT_FRAME:AddMessage("/flyout arrow [number|reset] - adjust the relative size of the flyout arrow")
+      DEFAULT_CHAT_FRAME:AddMessage("/flyout arrow [number||reset] - adjust the relative size of the flyout arrow")
       DEFAULT_CHAT_FRAME:AddMessage(" ")
    elseif args[1] == 'size' then
       if args[2] then


### PR DESCRIPTION
My initial plan was to just bring back the sticky feature I missed from the pre-rewrite version of Flyout, but of course I needed up doing more. 🙃 Please let me know if you would like me to revise anything.

### What's new
* The `[sticky]` flag is back.
* Cooldowns and highlights are displayed on Flyout action buttons.
* Arrows are scaled based on parent action button size (and scale can be customized through a slash command).
* Tooltips are refreshed to accurately show cooldown times.
* All all `/flyout` option commands now accept a `reset` verb.
* Some garbage collector optimizations and miscellaneous code cleanup.