### PR TITLE
Fix action bar button click to execute first Flyout action

### DIFF
--- a/Templates.xml
+++ b/Templates.xml
@@ -24,23 +24,19 @@
         </NormalTexture>
         <Scripts>
             <OnLoad>
-                this.action = ""
-                this.actionType = -1
+                this.flyoutAction = ""
+                this.flyoutActionType = -1
             </OnLoad>
             <OnClick>
-                if this.actionType == 0 then
-                    CastSpell(this.action, 'spell')
-                else
-                    Flyout_ExecuteMacro(this.action)
-                end
+                Flyout_Execute(this)
                 Flyout_Hide(true)
             </OnClick>
             <OnEnter>
                 GameTooltip_SetDefaultAnchor(GameTooltip, this)
-                if this.actionType == 0 then
-                    GameTooltip:SetSpell(this.action, 'spell')
-                else
-                    GameTooltip:SetText(GetMacroInfo(this.action), 1, 1, 1)
+                if this.flyoutActionType == 0 then
+                    GameTooltip:SetSpell(this.flyoutAction, 'spell')
+                elseif this.flyoutActionType == 1 then
+                    GameTooltip:SetText(GetMacroInfo(this.flyoutAction), 1, 1, 1)
                 end
                 GameTooltip:Show()
             </OnEnter>


### PR DESCRIPTION
Fix #7:
- Actions are now once again correctly mirrored from the first Flyout menu entry onto the action bar button.
- Light refactoring to unify code between Flyout menu buttons and action bar buttons using new Flyout_Execute() function.